### PR TITLE
fix ArrayIndexOutOfBoundsException when sDots[][] index >= length

### DIFF
--- a/patternlockview/src/main/java/com/andrognito/patternlockview/PatternLockView.java
+++ b/patternlockview/src/main/java/com/andrognito/patternlockview/PatternLockView.java
@@ -112,6 +112,7 @@ public class PatternLockView extends View {
     private float mHitFactor = 0.6f;
 
     // Made static so that the static inner class can use it
+    private static Dot[][] sDots;
     private static int sDotCount;
 
     private boolean mAspectRatioEnabled;
@@ -578,6 +579,13 @@ public class PatternLockView extends View {
 
     public void setDotCount(int dotCount) {
         sDotCount = dotCount;
+        sDots = new Dot[dotCount][dotCount];
+        for (int i = 0; i < dotCount; i++) {
+            for (int j = 0; j < dotCount; j++) {
+                sDots[i][j] = new Dot(i, j);
+            }
+        }
+
         mPatternSize = sDotCount * sDotCount;
         mPattern = new ArrayList<>(mPatternSize);
         mPatternDrawLookup = new boolean[sDotCount][sDotCount];
@@ -1149,7 +1157,6 @@ public class PatternLockView extends View {
 
         private int mRow;
         private int mColumn;
-        private static Dot[][] sDots;
 
         static {
             sDots = new Dot[sDotCount][sDotCount];

--- a/patternlockview/src/main/java/com/andrognito/patternlockview/PatternLockView.java
+++ b/patternlockview/src/main/java/com/andrognito/patternlockview/PatternLockView.java
@@ -586,11 +586,11 @@ public class PatternLockView extends View {
             }
         }
 
-        mPatternSize = sDotCount * sDotCount;
+        mPatternSize = dotCount * dotCount;
         mPattern = new ArrayList<>(mPatternSize);
-        mPatternDrawLookup = new boolean[sDotCount][sDotCount];
+        mPatternDrawLookup = new boolean[dotCount][dotCount];
 
-        mDotStates = new DotState[sDotCount][sDotCount];
+        mDotStates = new DotState[dotCount][dotCount];
         for (int i = 0; i < sDotCount; i++) {
             for (int j = 0; j < sDotCount; j++) {
                 mDotStates[i][j] = new DotState();


### PR DESCRIPTION
When changing the pattern dot count using `setDotCount()` PatternLockView.java throws an ArrayIndexOutOfBoundsException because `sDots` is not updated when `setDotCount()` is called.

Changelog:
- `sDots` is changed to a private static Dot[][] of PatternLockView class.
- `sDots` is updated to a new Dot[][] of the appropriate dotCount size.

closes https://github.com/aritraroy/PatternLockView/issues/10