### PR TITLE
fix for scrollable parent

### DIFF
--- a/patternlockview/src/main/java/com/andrognito/patternlockview/PatternLockView.java
+++ b/patternlockview/src/main/java/com/andrognito/patternlockview/PatternLockView.java
@@ -438,6 +438,7 @@ public class PatternLockView extends View {
 
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
+                getParent().requestDisallowInterceptTouchEvent(true);
                 handleActionDown(event);
                 return true;
             case MotionEvent.ACTION_UP:


### PR DESCRIPTION
 getParent().requestDisallowInterceptTouchEvent(true); This line prevents the parent view from scrolling when drawing pattern.