### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This library is available in **jCenter** which is the default Maven repository u
 dependencies {
     // other dependencies here
     
-    compile 'com.andrognito.patternlockview:patternlockview:1.0.0'
+    implementation 'com.andrognito.patternlockview:patternlockview:1.0.0'
     // Optional, for RxJava2 adapter
-    compile 'com.andrognito.patternlockview:patternlockview-reactive:1.0.0'
+    implementation 'com.andrognito.patternlockview:patternlockview-reactive:1.0.0'
 }
 ```
 


### PR DESCRIPTION
The ``compile`` dependency configuration is in fact deprecated and will be removed in Gradle version 7.0. Updated the example in the README to reflect using ``implementation`` in place of ``compile``. Currently utilizing this in one of my projects so thought I would help out.